### PR TITLE
Remove dupplicate output fields from OAI-PMH record header

### DIFF
--- a/modules/oaipmh/src/main/java/org/opencastproject/oaipmh/server/OaiXmlGen.java
+++ b/modules/oaipmh/src/main/java/org/opencastproject/oaipmh/server/OaiXmlGen.java
@@ -206,8 +206,6 @@ public abstract class OaiXmlGen extends XmlGen {
     if (item.isDeleted()) {
       header.setAttribute("status", "deleted");
     }
-    header.appendChild($eTxt("identifier", item.getId()));
-    header.appendChild($eTxt("datestamp", repository.toSupportedGranularity(item.getModificationDate())));
     for (String setSpec: item.getSetSpecs()) {
       header.appendChild($eTxt("setSpec", setSpec));
     }


### PR DESCRIPTION
The GetRecord output should contain only one identifier and datestamp elements and not like the sample below

```
<GetRecord>
<record>
<header>
<identifier>47c7ca12-2a1c-4bc3-822f-b29b62afee84</identifier>
<datestamp>2018-05-25T15:47:09Z</datestamp>
<identifier>47c7ca12-2a1c-4bc3-822f-b29b62afee84</identifier>
<datestamp>2018-05-25T15:47:09Z</datestamp>
<setSpec>advertised</setSpec>
<setSpec>inseries</setSpec>
</header>
<metadata>
…
```